### PR TITLE
Add back button to education screen

### DIFF
--- a/src/components/Education/index.js
+++ b/src/components/Education/index.js
@@ -11,6 +11,7 @@ import { Button, Text } from 'native-base';
 import Swiper from 'react-native-swiper'
 
 import { registerForPushNotificationsAsync } from '../../helpers/functions'
+import { withDrawer } from '../../helpers/drawer'
 
 const styles = StyleSheet.create({
   container: {
@@ -128,7 +129,8 @@ class Education extends Component {
 const mapStateToProps = (state, props) => {
     return {
         ...state.ui,
-        ...props.navigation.state.params
+        ...props.navigation.state.params,
+        portfolio: state.account.portfolio,
     }
 };
 
@@ -138,4 +140,4 @@ const mapDispatchToProps = (dispatch) => {
     }
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(Education);
+export default connect(mapStateToProps, mapDispatchToProps)(withDrawer(Education));

--- a/src/helpers/drawer.js
+++ b/src/helpers/drawer.js
@@ -70,7 +70,8 @@ export const withDrawer = (WrappedComponent) => {
 	        const icoDetails = navState.params && navState.params.ico || {}
             // Remove after: https://app.asana.com/0/425477633452716/477358357686745
             const showBackButton = [
-                'Token Details', 'Search', 'Price Alert', 'Add Address', 'ICO List', 'ICODetail'
+                'Token Details', 'Search', 'Price Alert', 'Add Address',
+                'ICO List', 'ICODetail', 'Education'
             ].indexOf(navState.routeName) > -1
 
             // add top padding for iphone X


### PR DESCRIPTION
<img width="277" alt="screen shot 2018-02-15 at 1 24 57 pm" src="https://user-images.githubusercontent.com/7131935/36256609-eadbd596-1253-11e8-8aee-367927663230.png">


@esco, quick question, is there a reason why this screen is called `education`?